### PR TITLE
Add ionic and cordova as a devDependency on the project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ log.txt
 *.sublime-project
 *.sublime-workspace
 .vscode/
+
+# errors
 npm-debug.log*
+yarn-error.log
 
 .idea/
 .sourcemaps/
@@ -33,3 +36,7 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+
+
+# lock-files
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -5,16 +5,11 @@
 
 ##### Installation :
 
-First install 
-```bash
-$ sudo npm install -g ionic cordova
-```
-
 Then, to run it, cd into `WeDonateMobileApp` and run:
 
 ``` bash
-$ npm install
-$ ionic serve 
+$ npm install or yarn install if using yarn
+$ npm run (or yarn run) ionic serve
 ```
 
 For Running in a Device

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "@ionic-native/splash-screen": "4.3.0",
     "@ionic-native/status-bar": "4.3.0",
     "@ionic/storage": "2.0.1",
+    "cordova-android": "~6.3.0",
     "cordova-browser": "~5.0.1",
+    "cordova-ios": "~4.5.3",
     "cordova-plugin-add-swift-support": "^1.7.0",
     "cordova-plugin-compat": "^1.2.0",
     "cordova-plugin-device": "^1.1.7",
@@ -45,16 +47,19 @@
     "socket.io": "^2.0.4",
     "socket.io-client": "^2.0.4",
     "sw-toolbox": "3.6.0",
-    "zone.js": "0.8.18",
-    "cordova-ios": "~4.5.3",
-    "cordova-android": "~6.3.0"
+    "zone.js": "0.8.18"
   },
   "devDependencies": {
     "@ionic/app-scripts": "3.0.0",
-    "ionic": "3.18.0",
+    "cordova": "^7.1.0",
+    "ionic": "^3.18.0",
     "typescript": "2.3.4"
   },
   "description": "An Ionic project",
+  "keywords": [
+    "cordova",
+    "ionic"
+  ],
   "cordova": {
     "plugins": {
       "cordova-plugin-nativestorage": {},


### PR DESCRIPTION
This adds:
-  `ionic` and `cordova` packages as `devDependencies` for not having to install them globally in the machine. 
 - => updates `README.md` accordingly 
- update on `package.json` adding  `keywords` array, we should also add a `node` and `npm` specification as well

